### PR TITLE
Cookie bug fix

### DIFF
--- a/django_app/core/views/cookie_views.py
+++ b/django_app/core/views/cookie_views.py
@@ -61,4 +61,6 @@ class HideCookiesView(FormView):
 
     def form_valid(self, form: HideCookiesForm) -> HttpResponse:
         referrer_url = self.request.session.get("redirect_back_to", "/")
+        if "cookies_set" in referrer_url:
+            referrer_url = referrer_url.replace("?cookies_set=true", "")
         return redirect(referrer_url)

--- a/django_app/core/views/cookie_views.py
+++ b/django_app/core/views/cookie_views.py
@@ -62,5 +62,5 @@ class HideCookiesView(FormView):
     def form_valid(self, form: HideCookiesForm) -> HttpResponse:
         referrer_url = self.request.session.get("redirect_back_to", "/")
         if "cookies_set" in referrer_url:
-            referrer_url = referrer_url.replace("?cookies_set", "removed_cookies_set")
+            referrer_url = referrer_url.replace("?cookies_set", "?removed_cookies_set")
         return redirect(referrer_url)

--- a/django_app/core/views/cookie_views.py
+++ b/django_app/core/views/cookie_views.py
@@ -62,5 +62,5 @@ class HideCookiesView(FormView):
     def form_valid(self, form: HideCookiesForm) -> HttpResponse:
         referrer_url = self.request.session.get("redirect_back_to", "/")
         if "cookies_set" in referrer_url:
-            referrer_url = referrer_url.replace("?cookies_set=true", "")
+            referrer_url = referrer_url.replace("?cookies_set", "removed_cookies_set")
         return redirect(referrer_url)

--- a/tests/test_unit/test_core/test_views/test_cookie_views.py
+++ b/tests/test_unit/test_core/test_views/test_cookie_views.py
@@ -42,4 +42,4 @@ def test_hide_cookies_view(al_client):
     session.save()
 
     response = al_client.post(reverse("hide_cookies"))
-    assert response.url == "/test_page"
+    assert response.url == "/test_page?removed_cookies_set=true"

--- a/tests/test_unit/test_core/test_views/test_cookie_views.py
+++ b/tests/test_unit/test_core/test_views/test_cookie_views.py
@@ -25,3 +25,21 @@ def test_redirect_works(al_client):
     session.save()
     response = al_client.post(reverse("cookies_consent"), data={"do_you_want_to_accept_analytics_cookies": "True"})
     assert response.url == "/?cookies_set=true"
+
+
+def test_hide_cookies_view(al_client):
+    response = al_client.post(reverse("hide_cookies"))
+    assert response.url == "/"
+
+    session = al_client.session
+    session["redirect_back_to"] = "/test_page?test=yes"
+    session.save()
+
+    response = al_client.post(reverse("hide_cookies"))
+    assert response.url == "/test_page?test=yes"
+
+    session["redirect_back_to"] = "/test_page?cookies_set=true"
+    session.save()
+
+    response = al_client.post(reverse("hide_cookies"))
+    assert response.url == "/test_page"


### PR DESCRIPTION
Accepting cookies -> click 'ou can change your cookie settings' - change preference -> back to page you were looking at -> Hide cookie message

Meant that the message was never hidden.