### PR TITLE
500 error when user accesses file upload page without verifying email

### DIFF
--- a/django_app/utils/s3.py
+++ b/django_app/utils/s3.py
@@ -30,20 +30,21 @@ def generate_presigned_url(s3_storage: Any, s3_file_object: Any) -> str:
 def get_all_session_files(s3_storage: S3Boto3Storage, session: SessionBase) -> dict[str, dict[str, str]]:
     """Gets all files that a user has uploaded in a session."""
     s3_client = get_s3_client_from_storage(s3_storage=s3_storage)
-    response = s3_client.list_objects_v2(Bucket=s3_storage.bucket.name, Prefix=session.session_key)
     session_files = {}
+    if not session.is_empty():
+        response = s3_client.list_objects_v2(Bucket=s3_storage.bucket.name, Prefix=session.session_key)
 
-    user_uploaded_files = get_user_uploaded_files(session)
-    for content in response.get("Contents", []):
-        key = content["Key"]
-        file_name = key.rpartition("/")[2]
+        user_uploaded_files = get_user_uploaded_files(session)
+        for content in response.get("Contents", []):
+            key = content["Key"]
+            file_name = key.rpartition("/")[2]
 
-        # checking that a file with this name was uploaded in the session
-        if file_name in user_uploaded_files:
-            session_files[key] = {
-                "file_name": file_name,
-                "url": reverse("download_document", kwargs={"file_name": file_name}),
-            }
+            # checking that a file with this name was uploaded in the session
+            if file_name in user_uploaded_files:
+                session_files[key] = {
+                    "file_name": file_name,
+                    "url": reverse("download_document", kwargs={"file_name": file_name}),
+                }
 
     return session_files
 

--- a/tests/test_frontend/test_feedback/test_collect_feedback.py
+++ b/tests/test_frontend/test_feedback/test_collect_feedback.py
@@ -13,7 +13,7 @@ class TestCollectFeedback(PlaywrightTestBase):
             self.page.get_by_test_id("collect_feedback_link").click()
 
             new_page = new_page_info.value
-            new_page.get_by_label("Very dissatisfied").click()
+            new_page.get_by_label("Very dissatisfied").check()
             new_page.get_by_role("checkbox", name="I did not find what I was looking for").click()
             new_page.get_by_role("button", name="Submit").click()
 

--- a/tests/test_unit/test_utils/test_s3.py
+++ b/tests/test_unit/test_utils/test_s3.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, Mock, patch
 
+from django.core.cache import cache
 from utils.s3 import get_all_session_files
 
 
@@ -9,9 +10,30 @@ def test_get_all_session_files(mocked_get_s3_client):
     mocked_get_s3_client.return_value.list_objects_v2 = MagicMock(return_value={"Contents": [{"Key": "test.png"}]})
 
     session_object = MagicMock()
+    session_object.is_empty = MagicMock(return_value=False)
     session_object.get = MagicMock(return_value=["test.png"])
+
     session_object.session_key = "test_session_key"
+    redis_cache_key = f"{session_object.session_key}"
+    cache.set(redis_cache_key, "test.png")
 
     session_files = get_all_session_files(Mock(), session_object)
     assert len(session_files) == 1
     assert "test.png" in session_files
+
+
+@patch("utils.s3.get_s3_client_from_storage")
+def test_no_session_returns_empty_session_files(mocked_get_s3_client):
+    mocked_get_s3_client.return_value = MagicMock()
+    mocked_get_s3_client.return_value.list_objects_v2 = MagicMock(return_value={"Contents": [{"Key": "test.png"}]})
+
+    session_object = MagicMock()
+    session_object.is_empty = MagicMock(return_value=True)
+    session_object.get = MagicMock(return_value=["test.png"])
+
+    session_object.session_key = "test_session_key"
+    redis_cache_key = f"{session_object.session_key}"
+    cache.set(redis_cache_key, "test.png")
+
+    session_files = get_all_session_files(Mock(), session_object)
+    assert len(session_files) == 0


### PR DESCRIPTION
Bugfix for this for both the upload documents and check your answers page:
it just returns empty session files if session doesn't exist and therefore no 500
